### PR TITLE
upload images to article

### DIFF
--- a/src/ui/ArticleEditor/ArticleEditor.tsx
+++ b/src/ui/ArticleEditor/ArticleEditor.tsx
@@ -52,6 +52,12 @@ const ArticleEditor: React.FC<ArticleEditorProps> = ({
 
   const router = useRouter();
   const [loadingText, setLoadingText] = useState<string | undefined>();
+  const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const handleCopy = () => {
+    copyToClipboard(`![Image description](${uploadedImageUrl})`);
+    setCopied(true);
+  };
 
   const {
     register,
@@ -208,7 +214,7 @@ const ArticleEditor: React.FC<ArticleEditorProps> = ({
                     if (updatePostRes.data.published) {
                       router.push(
                         `/${
-                          (updatePostRes.data as PostsJoins).user.username
+                          (fetchPost.data as PostsJoins).user.username
                         }/articles/${updatePostRes.data.slug}`
                       );
                     } else {
@@ -329,13 +335,6 @@ const ArticleEditor: React.FC<ArticleEditorProps> = ({
     }
   }, [watchedTextArea]);
 
-  const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
-  const handleCopy = () => {
-    copyToClipboard(`![Image description](${uploadedImageUrl})`);
-    setCopied(true);
-  };
-
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <Container size="common">
@@ -360,6 +359,7 @@ const ArticleEditor: React.FC<ArticleEditorProps> = ({
               onUpload={(url) => {
                 setUploadedImageUrl(url);
               }}
+              user_id={user_id}
             />
           </div>
           {uploadedImageUrl && (

--- a/src/ui/Layout/UserButton.tsx
+++ b/src/ui/Layout/UserButton.tsx
@@ -72,12 +72,13 @@ const UserDD: React.FC<UserDDProps> = () => {
           <DropdownMenuContent sideOffset={4}>
             <Link href={`/${user.username!}`} passHref>
               <DropdownMenuItem asChild>
-                <a className="block" onClick={onClose}>
+                <a className="block py-3" onClick={onClose}>
                   <h1 className="font-semibold text-sm">{user.display_name}</h1>
                   <h2 className="text-gray-400 text-xs">{`@${user.username}`}</h2>
                 </a>
               </DropdownMenuItem>
             </Link>
+            <DropdownMenuSeparator />
 
             <Link href={`/dashboard`} passHref>
               <DropdownMenuItem asChild>
@@ -128,7 +129,7 @@ const UserDD: React.FC<UserDDProps> = () => {
         </DropdownMenu>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button size="sm" color="primary">
+            <Button size="sm" color="primary" className="hidden sm:inline-flex">
               Add
             </Button>
           </DropdownMenuTrigger>

--- a/src/ui/Settings/UserForm.tsx
+++ b/src/ui/Settings/UserForm.tsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import toast from "react-hot-toast";
 import logger from "@/utils/logger";
-import { blacklistedUsernames } from "@/utils/const";
+import { avatarURL, blacklistedUsernames } from "@/utils/const";
 import { supabase } from "@/utils/supabaseClient";
 import { useAuth } from "context/auth";
 
@@ -64,17 +64,10 @@ const UserForm: React.FC<UserFormProps> = ({ user }) => {
             throw uploadResult.error;
           }
 
-          if (
-            data.avatarUrl.includes(
-              "https://anyqfjvtgmdymcwdoeac.supabase.co/storage/v1/object/public/avatar/"
-            )
-          ) {
+          if (data.avatarUrl.includes(avatarURL)) {
             // try to delete the old file
             try {
-              const path = data.avatarUrl.replace(
-                "https://anyqfjvtgmdymcwdoeac.supabase.co/storage/v1/object/public/avatar/",
-                ""
-              );
+              const path = data.avatarUrl.replace(avatarURL, "");
               await supabase.storage.from("avatar").remove([path]);
             } catch (error) {
               logger.debug("cant delete: ", data.avatarUrl);


### PR DESCRIPTION
## Can upload images to storage (public)
with the path: 
`uploads/(uid)/(imageid)`

have crud permission if **uid** is the same as request.
Currently uses this uploader on article editor


Other minor changes:

- Uses const on avatar url
- Added a divider in user dropdown